### PR TITLE
docs: CPLYTM-642 commands for generating real RHEL9 OSCAL Profiles

### DIFF
--- a/CONTENT_TRANSFORMATION.md
+++ b/CONTENT_TRANSFORMATION.md
@@ -1,11 +1,14 @@
-## Poetry Commands for RHEL9 Profile Generation
+## Poetry Commands for transforming RHEL9 Profiles in CaC/content to OSCAL Content
 
 The commands for each RHEL9 Profile transform CaC/content to an OSCAL Catalog, Profile(s), and Component Definition(s).
+
+The commands for transforming CaC/content leverage [trestle-bot](https://github.com/complytime/trestle-bot) for authoring OSCAL Content.
+
 
 ##### Generating OSCAL Profile from RHEL9 Profile with ANSSI content
 
 ```bash
-# Generating a OSCAL Catalog using the anssi policy-id from CaC/content
+# Generating an OSCAL Catalog using the anssi policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the anssi OSCAL Catalog and the RHEL9 CaC/content.
@@ -14,41 +17,63 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 # Generating an OSCAL Component Definition for anssi_bp28_minimal using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for anssi_bp28_minimal using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for anssi_bp28_intermediary using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-intermediary --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for anssi_bp28_intermediary using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-intermediary --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for anssi_bp28_high using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for anssi_bp28_high using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for anssi_bp28_enhanced using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_enhanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-enhanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for anssi_bp28_enhanced using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_enhanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-enhanced --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with CCN content
 
 ```bash
 
-# Generating a OSCAL Catalog using the ccn_rhel9 policy-id from CaC/content
+# Generating an OSCAL Catalog using the ccn_rhel9 policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ccn_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ccn_basic using the profile created and the RHEL9 CaC/content.
- poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-basic --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-basic --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for ccn_basic using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-basic --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ccn_intermediate using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_intermediate --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-intermediate --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for ccn_intermediate using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_intermediate --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-intermediate --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for ccn_advanced using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_advanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-advanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for ccn_advanced using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_advanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-advanced --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with CIS content
 
 ```bash
 
-# Generating a OSCAL Catalog using the cis_rhel9 policy-id from CaC/content
+# Generating an OSCAL Catalog using the cis_rhel9 policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the cis_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
@@ -57,21 +82,33 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 # Generating an OSCAL Component Definition for cis_server_l1 using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for cis_server_l1 using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_server --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for cis using the cis_rhel9-l2_server profile created and the RHEL9 CaC/content.
- poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for cis using the cis_rhel9-l2_server profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_server --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for cis_workstation_l1 using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for cis_workstation_l1 using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_workstation --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for cis_workstation_l2 using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l2 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for cis_workstation_l2 using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l2 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_workstation --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with OSPP content
 
 ```bash
 
-# Generating a OSCAL Catalog using the ospp policy-id from CaC/content
+# Generating an OSCAL Catalog using the ospp policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
@@ -79,13 +116,16 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 
 # Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for ospp using the ospp-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 
 ##### Generating OSCAL Profile from RHEL9 Profile with OSPP and CUI content
 ```bash
 
-# Generating a OSCAL Catalog using the ospp policy-id from CaC/content
+# Generating an OSCAL Catalog using the ospp policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
@@ -93,13 +133,16 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 
 # Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for ospp using the ospp-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with E8 content
 
 ```bash
 
-# Generating a OSCAL Catalog using the e8 policy-id from CaC/content
+# Generating an OSCAL Catalog using the e8 policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the e8 OSCAL Catalog and the RHEL9 CaC/content.
@@ -107,13 +150,16 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 
 # Generating an OSCAL Component Definition for e8 using the e8-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-trestle-demos --oscal-profile e8-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for e8 using the e8-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-trestle-demos --oscal-profile e8-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with HIPAA content
 
 ```bash
 
-# Generating a OSCAL Catalog using the hipaa policy-id from CaC/content
+# Generating an OSCAL Catalog using the hipaa policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --branch main --committer-name test --committer-email test@redhat.com --dry-run  
 
 # Generating an OSCAL Profile leveraging the hipaa OSCAL Catalog and the RHEL9 CaC/content.
@@ -122,38 +168,54 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 # Generating an OSCAL Component Definition for hipaa using the hipaa-addressable profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-addressable --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for hipaa using the hipaa-addressable profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-addressable --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for hipaa using the hipaa-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for hipaa using the hipaa-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for hipaa using the hipaa-required profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-required --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for hipaa using the hipaa-required profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-required --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with ISM content
 
 ```bash
-# Generating a OSCAL Catalog using the ism_o policy-id from CaC/content
+# Generating an OSCAL Catalog using the ism_o policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --branch main --committer-name test --committer-email test@redhat.com --dry-run  
 
 # Generating an OSCAL Profile leveraging the ism_o OSCAL Catalog and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
-
 # Generating an OSCAL Component Definition for ism_o using the ism_o-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for ism_o using the ism_o-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ism_o using the ism_o-secret profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for ism_o using the ism_o-secret profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-secret --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for ism_o using the ism_o-top_secret profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-top_secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for ism_o using the ism_o-top_secret profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-top_secret --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 ##### Generating OSCAL Profile from RHEL9 Profile with PCI-DSS content
 
 ```bash
 
-# Generating a OSCAL Catalog using the pcidss_4 policy-id from CaC/content
+# Generating an OSCAL Catalog using the pcidss_4 policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the pcidss_4 OSCAL Catalog and the RHEL9 CaC/content.
@@ -161,13 +223,16 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 
 # Generating an OSCAL Component Definition for pci-dss using the pcidss_4-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-trestle-demos --oscal-profile pcidss_4-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for pci-dss using the pcidss_4-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-trestle-demos --oscal-profile pcidss_4-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with STIG content
 
 ```bash
 
-# Generating a OSCAL Catalog using the stig_rhel9 policy-id from CaC/content
+# Generating an OSCAL Catalog using the stig_rhel9 policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run 
 
 # Generating an OSCAL Profile leveraging the stig_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
@@ -176,17 +241,26 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 # Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-low profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for pci-dss using the stig_rhel9-low profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for pci-dss using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-high profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for pci-dss using the stig_rhel9-high profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile for stig_gui with STIG content
 
 ```bash
-# Generating a OSCAL Catalog using the stig_rhel9 policy-id from CaC/content
+# Generating an OSCAL Catalog using the stig_rhel9 policy-id from CaC/content.
 poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the stig_gui OSCAL Catalog and the RHEL9 CaC/content.
@@ -195,10 +269,19 @@ poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-roo
 # Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-low profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for stig_gui using the stig_rhel9-low profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
+# Updating an OSCAL Component Definition to include a validation component for stig_gui using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
 # Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-high profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Updating an OSCAL Component Definition to include a validation component for stig_gui using the stig_rhel9-high profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 

--- a/CONTENT_TRANSFORMATION.md
+++ b/CONTENT_TRANSFORMATION.md
@@ -1,0 +1,204 @@
+## Poetry Commands for RHEL9 Profile Generation
+
+The commands for each RHEL9 Profile transform CaC/content to an OSCAL Catalog, Profile(s), and Component Definition(s).
+
+##### Generating OSCAL Profile from RHEL9 Profile with ANSSI content
+
+```bash
+# Generating a OSCAL Catalog using the anssi policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the anssi OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for anssi_bp28_minimal using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for anssi_bp28_intermediary using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-intermediary --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for anssi_bp28_high using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for anssi_bp28_enhanced using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_enhanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-enhanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile with CCN content
+
+```bash
+
+# Generating a OSCAL Catalog using the ccn_rhel9 policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the ccn_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for ccn_basic using the profile created and the RHEL9 CaC/content.
+ poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-basic --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for ccn_intermediate using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_intermediate --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-intermediate --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for ccn_advanced using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_advanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-advanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile with CIS content
+
+```bash
+
+# Generating a OSCAL Catalog using the cis_rhel9 policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the cis_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for cis_server_l1 using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for cis using the cis_rhel9-l2_server profile created and the RHEL9 CaC/content.
+ poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for cis_workstation_l1 using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for cis_workstation_l2 using the profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l2 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile with OSPP content
+
+```bash
+
+# Generating a OSCAL Catalog using the ospp policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+
+##### Generating OSCAL Profile from RHEL9 Profile with OSPP and CUI content
+```bash
+
+# Generating a OSCAL Catalog using the ospp policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile with E8 content
+
+```bash
+
+# Generating a OSCAL Catalog using the e8 policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the e8 OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for e8 using the e8-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-trestle-demos --oscal-profile e8-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile with HIPAA content
+
+```bash
+
+# Generating a OSCAL Catalog using the hipaa policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --branch main --committer-name test --committer-email test@redhat.com --dry-run  
+
+# Generating an OSCAL Profile leveraging the hipaa OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for hipaa using the hipaa-addressable profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-addressable --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for hipaa using the hipaa-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for hipaa using the hipaa-required profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-required --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile with ISM content
+
+```bash
+# Generating a OSCAL Catalog using the ism_o policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --branch main --committer-name test --committer-email test@redhat.com --dry-run  
+
+# Generating an OSCAL Profile leveraging the ism_o OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+
+# Generating an OSCAL Component Definition for ism_o using the ism_o-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+
+# Generating an OSCAL Component Definition for ism_o using the ism_o-secret profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for ism_o using the ism_o-top_secret profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-top_secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+##### Generating OSCAL Profile from RHEL9 Profile with PCI-DSS content
+
+```bash
+
+# Generating a OSCAL Catalog using the pcidss_4 policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the pcidss_4 OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for pci-dss using the pcidss_4-base profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-trestle-demos --oscal-profile pcidss_4-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile with STIG content
+
+```bash
+
+# Generating a OSCAL Catalog using the stig_rhel9 policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run 
+
+# Generating an OSCAL Profile leveraging the stig_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-low profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-high profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+
+##### Generating OSCAL Profile from RHEL9 Profile for stig_gui with STIG content
+
+```bash
+# Generating a OSCAL Catalog using the stig_rhel9 policy-id from CaC/content
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --branch main --committer-name test --committer-email test@redhat.com --dry-run
+
+# Generating an OSCAL Profile leveraging the stig_gui OSCAL Catalog and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-low profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+
+# Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-high profile created and the RHEL9 CaC/content.
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+```
+

--- a/README.md
+++ b/README.md
@@ -124,13 +124,18 @@ poetry run trestlebot catalog --cac-content-root ~/CaC/Forks/content --policy-id
 poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/Forks/content --policy-id anssi --repo-path ~/LABs/trestlebot-labs/ --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # With a profile available, an OSCAL Component Definition can be created using information from anssi_bp28_minimal profile for RHEL 9 product
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile ~/CaC/Forks/content/products/rhel9/profiles/anssi_bp28_minimal.profile --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type software --committer-name marcusburghardt --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile anssi_bp28_minimal --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Finally the new Component Definition can be updated to include a validation component, to be used by openscap-plugin later
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile ~/CaC/Forks/content/products/rhel9/profiles/anssi_bp28_minimal.profile --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type validation --committer-name marcusburghardt --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile ~/CaC/Forks/content/products/rhel9/profiles/anssi_bp28_minimal.profile --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 After these commands, the generated component definition and the chosen profile files were copied to `base_ansible_env/files` to be used with `populate_complytime_anssi_content.yml` Playbook.
+
+### Generating OSCAL Content from CaC/content transformation
+
+The commands for transforming CaC/content are organized by policy_id in the [CONTENT_TRANSFORMATION.md](https://github.com/complytime/complytime-demos/blob/d403cb455f4bf6f4e4dd9e7d7fc724d9e0b0e321/CONTENT_TRANSFORMATION.md).
+
 
 ### Try ComplyTime commands
 


### PR DESCRIPTION
#### What does this PR introduce?

This PR addresses the need for users to easily run commands in trestle-bot for generating OSCAL content using real RHEL9 profiles in the CaC/content repo.

The PR outlines the steps for running the `sync-cac-content` command with sub-commands: `catalog`, `profile`, and `component-definition`. The sub-headings indicate the RHEL9 content that is referenced for generating each OSCAL Catalog, Profile, and Component Definition(s). The commands are grouped by RHEL9 Profile and `policy_id`.  The updates are linked to the `README.md` from the `CONTENT_TRANSFORMATION.md` file. 

**Notable changes for users leveraging the commands:**

Commands can be copied directly from page. Ensure that command flags listed below are updated for consistency with credentials specific to user workspace. 
1. `--repo-path`
2. `--cac-content-root`
3. `--committer-email`
4. `--committer-name`

#### Potential Suggestions for code introduced

This PR has potential to break-out into a separate file for `CONTENT-TRANSFORMATION.md` which could include the section that was added to the `README.md`, but linked to the `.md` rather than explicitly listed in the `README.md`.

#### Review Hints

- Review each of the commits and their contents to validate the commands run
- Tested using the CLI