### PR TITLE
Initial SPEC file and Playbook for ComplyTime RPM

### DIFF
--- a/base_ansible_env/files/complytime.spec
+++ b/base_ansible_env/files/complytime.spec
@@ -1,0 +1,63 @@
+Name:           complytime
+Version:        0.0.2
+Release:        1%{?dist}
+Summary:        ComplyTime leverages OSCAL to perform compliance assessment activities, using plugins for each stage of the lifecycle.
+
+License:        Apache-2.0
+URL:            https://github.com/complytime/complytime
+Source0:        https://github.com/complytime/complytime/archive/refs/tags/v0.0.2.tar.gz
+
+BuildRequires:  golang
+BuildRequires:  make
+
+%description
+ComplyTime leverages OSCAL to perform compliance assessment activities, using plugins for each stage of the lifecycle.
+
+%package        openscap-plugin
+Summary:        A plugin which extends the ComplyTime capabilities to use OpenSCAP
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       scap-security-guide
+%description    openscap-plugin
+openscap-plugin is a plugin which extends the ComplyTime capabilities to use OpenSCAP. The plugin communicates
+with ComplyTime via gRPC, providing a standard and consistent communication mechanism that gives independence
+for plugin developers to choose their preferred languages.
+
+%prep
+%setup -q
+
+%undefine _missing_build_ids_terminate_build
+%undefine _debugsource_packages
+
+%build
+make build
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+install -m 0755 bin/complytime %{buildroot}%{_bindir}/complytime
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/plugins
+install -m 0755 bin/openscap-plugin %{buildroot}%{_libexecdir}/%{name}/plugins/openscap-plugin
+mkdir -p %{buildroot}%{_datadir}/%{name}
+cp -rf docs/samples %{buildroot}%{_datadir}/%{name}
+# TODO: Manifest file, related issue: CPLYTM-682
+mkdir -p %{buildroot}%{_datadir}/%{name}/plugins
+
+%check
+make test-unit
+
+%files
+%license LICENSE
+%{_bindir}/complytime
+%doc README.md
+%defattr(-,root,root,644)
+%{_datadir}/%{name}
+
+%files          openscap-plugin
+%{_libexecdir}/%{name}/plugins/openscap-plugin
+%doc cmd/openscap-plugin/README.md
+
+%changelog
+* Fri Apr 11 2025 Qingmin Duanmu <qduanmu@redhat.com>
+- Separate package for openscap-plugin
+
+* Tue Apr 08 2025 Marcus Burghardt <maburgha@redhat.com>
+- Initial RPM

--- a/base_ansible_env/populate_complytime_rpm.yml
+++ b/base_ansible_env/populate_complytime_rpm.yml
@@ -1,0 +1,44 @@
+---
+- name: "Prepare the environment to build ComplyTime RPM on the Demo VM"
+  hosts: demo_vm
+  become: false
+  tasks:
+    - name: Install required packages
+      ansible.builtin.dnf:
+        name:
+          - git
+          - make
+          - go-toolset
+        state: present
+      become: true
+
+    - name: "Copy ComplyTime SPEC file to Demo VM"
+      ansible.builtin.copy:
+        src: "complytime.spec"
+        dest: "~"
+        mode: "0640"
+
+    - name: "Ensure the RPM build tree is created"
+      ansible.builtin.command:
+        cmd: "rpmdev-setuptree"
+      changed_when: false
+
+    - name: "Download the ComplyTime source code as informed in the SPEC file"
+      ansible.builtin.command:
+        cmd: "spectool -g complytime.spec"
+      changed_when: false
+
+    - name: "Copy ComplyTime source code to the RPM build tree"
+      ansible.builtin.copy:
+        src: "~/v0.0.2.tar.gz"
+        dest: "~/rpmbuild/SOURCES/"
+        mode: "0640"
+        remote_src: true
+
+    - name: "Ensure GOTOOLCHAIN=auto is set for a specific user"
+      ansible.builtin.lineinfile:
+        path: ~/.bashrc
+        line: 'export GOTOOLCHAIN=auto'
+        insertafter: EOF
+        state: present
+...


### PR DESCRIPTION
This SPEC file is used for testing purposes only.
There is also a new Ansible Playbook to populate a RHEL 9 VM with this SPEC file and required packages to build the RPM.

In order to test, after the RHEL 9 VM is running:
```
ansible-playbook populate_complytime_rpm.yml
```
Then you can connect on the VM and execute:
```
rpmbuild -ba complytime.spec
tree
rpm -pql rpmbuild/RPMS/x86_64/complytime-0.0.2-1.el9.x86_64.rpm
rpm -ivh rpmbuild/RPMS/x86_64/complytime-0.0.2-1.el9.x86_64.rpm
whereis complytime
```