### PR TITLE
docs: adding cac prefix to policy-id flags

### DIFF
--- a/CONTENT_TRANSFORMATION.md
+++ b/CONTENT_TRANSFORMATION.md
@@ -8,11 +8,11 @@ The commands for transforming CaC/content leverage [trestle-bot](https://github.
 ##### Generating OSCAL Profile from RHEL9 Profile with ANSSI content
 
 ```bash
-# Generating an OSCAL Catalog using the anssi policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the anssi cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the anssi OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for anssi_bp28_minimal using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -44,11 +44,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 
 ```bash
 
-# Generating an OSCAL Catalog using the ccn_rhel9 policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the ccn_rhel9 cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ccn_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ccn_basic using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-basic --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -73,11 +73,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 
 ```bash
 
-# Generating an OSCAL Catalog using the cis_rhel9 policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the cis_rhel9 cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the cis_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for cis_server_l1 using the profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -108,11 +108,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 
 ```bash
 
-# Generating an OSCAL Catalog using the ospp policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the ospp cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -125,11 +125,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ##### Generating OSCAL Profile from RHEL9 Profile with OSPP and CUI content
 ```bash
 
-# Generating an OSCAL Catalog using the ospp policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the ospp cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -142,11 +142,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 
 ```bash
 
-# Generating an OSCAL Catalog using the e8 policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the e8 cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the e8 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for e8 using the e8-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-trestle-demos --oscal-profile e8-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -159,11 +159,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 
 ```bash
 
-# Generating an OSCAL Catalog using the hipaa policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --branch main --committer-name test --committer-email test@redhat.com --dry-run  
+# Generating an OSCAL Catalog using the hipaa cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --branch main --committer-name test --committer-email test@redhat.com --dry-run  
 
 # Generating an OSCAL Profile leveraging the hipaa OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for hipaa using the hipaa-addressable profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-addressable --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -187,11 +187,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ##### Generating OSCAL Profile from RHEL9 Profile with ISM content
 
 ```bash
-# Generating an OSCAL Catalog using the ism_o policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --branch main --committer-name test --committer-email test@redhat.com --dry-run  
+# Generating an OSCAL Catalog using the ism_o cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --branch main --committer-name test --committer-email test@redhat.com --dry-run  
 
 # Generating an OSCAL Profile leveraging the ism_o OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ism_o using the ism_o-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -215,11 +215,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 
 ```bash
 
-# Generating an OSCAL Catalog using the pcidss_4 policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the pcidss_4 cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the pcidss_4 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for pci-dss using the pcidss_4-base profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-trestle-demos --oscal-profile pcidss_4-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -232,11 +232,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 
 ```bash
 
-# Generating an OSCAL Catalog using the stig_rhel9 policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run 
+# Generating an OSCAL Catalog using the stig_rhel9 cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run 
 
 # Generating an OSCAL Profile leveraging the stig_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-low profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
@@ -260,11 +260,11 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ##### Generating OSCAL Profile from RHEL9 Profile for stig_gui with STIG content
 
 ```bash
-# Generating an OSCAL Catalog using the stig_rhel9 policy-id from CaC/content.
-poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --branch main --committer-name test --committer-email test@redhat.com --dry-run
+# Generating an OSCAL Catalog using the stig_rhel9 cac-policy-id from CaC/content.
+poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the stig_gui OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-low profile created and the RHEL9 CaC/content.
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ For reference, these were the commands used with trestlebot to transform the ANS
 
 ```bash
 # Create a OSCAL catalog based on ANSSI control file in CaC/content
-poetry run trestlebot catalog --cac-content-root ~/CaC/Forks/content --policy-id anssi --repo-path ~/LABs/trestlebot-labs --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run trestlebot catalog --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Once a catalog is available, the ANSSI profiles can be created based on control file information in CaC/content
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/Forks/content --policy-id anssi --repo-path ~/LABs/trestlebot-labs/ --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs/ --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # With a profile available, an OSCAL Component Definition can be created using information from anssi_bp28_minimal profile for RHEL 9 product
 poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile anssi_bp28_minimal --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run


### PR DESCRIPTION
### PR Description 

This PR updates the `CONTENT_TRANSFORMATION.md` and `README.md` to refernce the `ComplianceAsCode/content` control files as `--cac-policy-id`. This update allows users to easily reproduce the commands using the corrected flags. 

### Relevant issues

- [trestle-bot PR](https://github.com/complytime/trestle-bot/commit/e5c449823b0948a25c0f65cce96b59addb9f5539) that updates `--policy-id` to `--cac-policy-id`.

### Testing Hints

- Run the commands for trestlebot as usual but instead of passing the CaC/content control file as `--policy id <value>` use `--cac-policy-id <value>`.

**Commands for authoring RHEL9 anssi OSCAL Content**
- OSCAL Catalog: `poetry run trestlebot catalog --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run`

-  OSCAL Profiles: `poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs/ --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run`
