### PR TITLE
Remove manual tasks from VM provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # VMs
 .vagrant/
+
+# Ignore local changes to this file
+base_ansible_env/ansible_inventory

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ complytime-demos/
 │ ├── populate_ansible_inventory.sh # Script to collect information for Vagrant VM and populate the Ansible inventory
 │ └── Vagrantfile                   # Vagrant instructions to create a local VM
 ├── scripts/                        # Supporting scripts (WIP)
+├── CONTENT_TRANSFORMATION.md       # Examples of commands used in trestle-bot to generate OSCAL content based in ComplianceAsCode/content
 └── README.md                       # Main file to centralize instructions and other relevant information for demos.s
 ```
 
@@ -41,7 +42,6 @@ complytime-demos/
 git clone https://github.com/marcusburghardt/complytime-demos.git
 cd complytime-demos/base_rhel9_vm
 vagrant up
-./populate_ansible_inventory.sh
 ```
 
 It is recommended to create a snapshot of the fresh VM if you plan to work on a new Demo or experiment different Demos.

--- a/base_rhel9_vm/Vagrantfile
+++ b/base_rhel9_vm/Vagrantfile
@@ -63,4 +63,9 @@ gpgcheck=0" > /etc/yum.repos.d/cac.repo
   dnf upgrade -y
   SCRIPT
   config.vm.provision "shell", inline: $bootstrap
+
+  config.trigger.after :up do |trigger|
+    trigger.name = "Execute local script to update Ansible inventory and add SSH key"
+    trigger.run = { inline: "./populate_ansible_inventory.sh" }
+  end
 end

--- a/base_rhel9_vm/populate_ansible_inventory.sh
+++ b/base_rhel9_vm/populate_ansible_inventory.sh
@@ -4,7 +4,12 @@
 # Get Vagrant SSH configuration
 VAGRANT_SSH_CONFIG=$(vagrant ssh-config)
 
-# Extract the name and IP address of the VM
+# Add the VM's IP address to the known_hosts file to avoid SSH prompts
+IP=$(echo "$VAGRANT_SSH_CONFIG" | awk '/HostName/ {print $2}')
+ssh-keyscan -H "$IP" >> ~/.ssh/known_hosts 2>/dev/null
+echo "IP address $IP added to known_hosts file."
+
+# Populate the Ansible inventory file with the VM's SSH configuration
 echo "[demo_vm]" > ../base_ansible_env/ansible_inventory
 echo "$VAGRANT_SSH_CONFIG" | awk '
 /Host / {host=$2}
@@ -15,7 +20,6 @@ END {print host, "ansible_host="hostname, "ansible_user=ansible", "ansible_ssh_p
 echo "Inventory file generated successfully!"
 cat ../base_ansible_env/ansible_inventory
 
-echo ""
 echo "You can connect to the VMs using the following command:"
 echo "$VAGRANT_SSH_CONFIG" | awk '
 /HostName/ {hostname=$2}


### PR DESCRIPTION
After provisioning a new Vagrant Box there are some steps specific for this test environment, such as:
- Updating a local Ansible inventory
  - There was a script for this already, but now it is executed automatically right after the vagrant box being created
- Add the host key during the first ssh connection
  - It was a manual process that is now included in the script.

The Ansible inventory is updated whenever a new box is created. The changes are local so now they are ignored for git.
This PR also do some minor updates to README.md.

## Review Hints

```
cd complytime-demos/base_rhel9_vm
vagrant up
```