### PR TITLE
feat: CPLYTM-857 - introduce vagrant box for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ complytime-demos/
 │ ├── templates/                    # Jinja2 templates used by Playbooks
 │ ├── ansible_inventory             # This file is automatically updated by "populate_ansible_inventory.sh"
 │ └── ansible.cfg                   # Ansible configuration file specific for "base_ansible_env" directory
-├── base_rhel9_env/                 # Centralize instructions to create a rhel9 demo VM
-│ ├── populate_ansible_inventory.sh # Script to collect information for Vagrant VM and populate the Ansible inventory
-│ └── Vagrantfile                   # Vagrant instructions to create a local VM
+├── base_vms/                       # Centralize instructions to create demo VMs
+│ ├── fedora                        # Instructions to create a fedora demo VM
+│ │   └── Vagrantfile               # Vagrant instructions to create a local fedora VM
+│ ├── rhel9                         # Instructions to create a rhel9 demo VM
+│ │   └── Vagrantfile               # Vagrant instructions to create a local rhel9 VM
+│ └── populate_ansible_inventory.sh # Script to collect information from Vagrant VM and populate the Ansible inventory
 ├── scripts/                        # Supporting scripts (WIP)
 ├── CONTENT_TRANSFORMATION.md       # Examples of commands used in trestle-bot to generate OSCAL content based in ComplianceAsCode/content
 └── README.md                       # Main file to centralize instructions and other relevant information for demos.s
@@ -40,12 +43,18 @@ complytime-demos/
 
 ```bash
 git clone https://github.com/marcusburghardt/complytime-demos.git
-cd complytime-demos/base_rhel9_vm
+cd complytime-demos/base_vms/rhel9
 vagrant up
 ```
 
 It is recommended to create a snapshot of the fresh VM if you plan to work on a new Demo or experiment different Demos.
 This way you can save time provisioning a new Vagrant Box.
+
+### Base Fedora VM
+```bash
+cd complytime-demos/base_vms/fedora
+vagrant up
+```
 
 #### Connect to the Demo VM
 
@@ -54,7 +63,7 @@ You can connect using vagrant command:
 vagrant ssh
 ```
 
-Or you can connect via SSH using the hint from `./populate_ansible_inventory.sh` script. e.g.:
+Or you can connect via SSH using the hint from `populate_ansible_inventory.sh` script. e.g.:
 ```bash
 ssh ansible@192.168.122.161
 ```
@@ -116,28 +125,14 @@ After running this Playbook a directory structure similar to this is expected in
 ```
 
 #### Regenerate ANSSI content
-For reference, these were the commands used with complyscribe to transform the ANSSI content in this example:
 
-```bash
-# Create a OSCAL catalog based on ANSSI control file in CaC/content
-poetry run complyscribe catalog --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
+For reference, the commands used with trestlebot to transform the ANSSI content can be found [here](https://github.com/complytime/complytime-demos/blob/main/CONTENT_TRANSFORMATION.md#generating-oscal-profile-from-rhel9-profile-with-anssi-content)
 
-# Once a catalog is available, the ANSSI profiles can be created based on control file information in CaC/content
-poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs/ --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
-
-# With a profile available, an OSCAL Component Definition can be created using information from anssi_bp28_minimal profile for RHEL 9 product
-poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile anssi_bp28_minimal --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
-
-# Finally the new Component Definition can be updated to include a validation component, to be used by openscap-plugin later
-poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile ~/CaC/Forks/content/products/rhel9/profiles/anssi_bp28_minimal.profile --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
-```
-
-After these commands, the generated component definition and the chosen profile files were copied to `base_ansible_env/files` to be used with `populate_complytime_anssi_content.yml` Playbook.
+After the transformation commands, the component definition and the chosen profile files were copied to `base_ansible_env/files` to be used with `populate_complytime_anssi_content.yml` Playbook.
 
 ### Generating OSCAL Content from CaC/content transformation
 
 The commands for transforming CaC/content are organized by policy_id in the [CONTENT_TRANSFORMATION.md](https://github.com/complytime/complytime-demos/blob/d403cb455f4bf6f4e4dd9e7d7fc724d9e0b0e321/CONTENT_TRANSFORMATION.md).
-
 
 ### Try complyctl commands
 

--- a/base_ansible_env/ansible.cfg
+++ b/base_ansible_env/ansible.cfg
@@ -6,3 +6,5 @@ remote_user     = ansible
 ask_pass        = false
 sudo_user       = ansible
 ask_sudo_pass   = false
+
+interpreter_python = auto_silent

--- a/base_ansible_env/ansible_inventory
+++ b/base_ansible_env/ansible_inventory
@@ -1,2 +1,0 @@
-[demo_vm]
-rhel9 ansible_host=192.168.122.5 ansible_user=ansible ansible_ssh_private_key_file=~/.ssh/id_rsa

--- a/base_ansible_env/populate_complyctl_vm.yml
+++ b/base_ansible_env/populate_complyctl_vm.yml
@@ -1,33 +1,33 @@
 ---
-- name: "Prepare the ComplyTime environment on the Demo VM"
+- name: "Prepare the complyctl environment on the Demo VM"
   hosts: demo_vm
   become: false
   vars:
-    # Update according to where https://github.com/complytime/complytime.git was cloned
-    complytime_repo_dest: "~/GIT/ProdSec/complytime"
-    complytime_workspace: "~/.local/share/complytime"
+    # Update according to where https://github.com/complytime/complyctl.git was cloned
+    complyctl_repo_dest: "~/GIT/ProdSec/complyctl"
+    complyctl_workspace: "~/.local/share/complytime"
 
   tasks:
     - name: "Lets Pray for the God of Demos"
       ansible.builtin.debug:
         msg: "Please, give me power to make this demo work! Or creativity to find good excuses. :)"
 
-    - name: "Build ComplyTime locally"
+    - name: "Build complyctl locally"
       ansible.builtin.command:
         cmd: "make build"
-        chdir: "{{ complytime_repo_dest }}"
+        chdir: "{{ complyctl_repo_dest }}"
       delegate_to: localhost
 
-    - name: "Ensure bin directory in home directory to make it easier to call ComplyTime"
+    - name: "Ensure bin directory in home directory to make it easier to call complyctl"
       ansible.builtin.file:
         path: "~/bin"
         state: directory
         mode: "0750"
 
-    - name: "Copy ComplyTime binary to Demo VM"
+    - name: "Copy complyctl binary to Demo VM"
       ansible.builtin.copy:
-        src: "{{ complytime_repo_dest }}/bin/complytime"
-        dest: "~/bin/complytime"
+        src: "{{ complyctl_repo_dest }}/bin/complyctl"
+        dest: "~/bin/complyctl"
         mode: "0750"
 
     - name: "Ensure COMPLYTIME_DEV_MODE=1 is set for a specific user"
@@ -37,35 +37,35 @@
         insertafter: EOF
         state: present
 
-    - name: "Check existing ComplyTime directories in case there is already a Workspace"
+    - name: "Check existing complyctl directories in case there is already a Workspace"
       ansible.builtin.stat:
-        path: "{{ complytime_workspace }}"
-      register: result_complytime_workspace
+        path: "{{ complyctl_workspace }}"
+      register: result_complyctl_workspace
 
-    - name: "Initialize ComplyTime to ensure the Workspace is created"
+    - name: "Initialize complyctl to ensure the Workspace is created"
       ansible.builtin.command:
-        cmd: "~/bin/complytime list"
+        cmd: "~/bin/complyctl list"
       environment:
         COMPLYTIME_DEV_MODE: "1"
       failed_when: false
-      changed_when: not result_complytime_workspace.stat.exists
-      when: not result_complytime_workspace.stat.exists
+      changed_when: not result_complyctl_workspace.stat.exists
+      when: not result_complyctl_workspace.stat.exists
 
     - name: "Copy OpenSCAP plugin binary to Demo VM"
       ansible.builtin.copy:
-        src: "{{ complytime_repo_dest }}/bin/openscap-plugin"
-        dest: "{{ complytime_workspace }}/plugins"
+        src: "{{ complyctl_repo_dest }}/bin/openscap-plugin"
+        dest: "{{ complyctl_workspace }}/plugins"
         mode: "0750"
 
     - name: "Compute SHA256 checksum of the openscap-plugin binary"
       ansible.builtin.stat:
-        path: "{{ complytime_workspace }}/plugins/openscap-plugin"
+        path: "{{ complyctl_workspace }}/plugins/openscap-plugin"
         checksum_algorithm: sha256
       register: result_plugin_checksum
 
     - name: "Create or Update the openscap-plugin manifest"
       ansible.builtin.template:
         src: c2p-openscap-manifest.json.j2
-        dest: "{{ complytime_workspace }}/plugins/c2p-openscap-manifest.json"
+        dest: "{{ complyctl_workspace }}/plugins/c2p-openscap-manifest.json"
         mode: "0640"
 ...

--- a/base_vms/fedora/Vagrantfile
+++ b/base_vms/fedora/Vagrantfile
@@ -6,34 +6,14 @@ Vagrant.configure("2") do |config|
     libvirt.memory = "2048"
     libvirt.cpus = 2
     libvirt.default_prefix = "complytime_"
+    libvirt.machine_virtual_size = 10
     libvirt.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 
-  config.vm.define "rhel9" do |rhel|
-    rhel.vm.box = "generic/rhel9"
-    rhel.vm.hostname = "rhel9"
+  config.vm.define "fedora" do |fedora|
+    fedora.vm.box = "fedora/41-cloud-base"
+    fedora.vm.hostname = "fedora"
   end
-
-  # This Vagrantfile is using a publicly available Box and, therefore, without a valid
-  # subscription. Testing repositories can be included as needed.
-  RHEL_BASE_REPO = "http://download.eng.brq.redhat.com/rhel-9/rel-eng/RHEL-9/latest-RHEL-9/compose/BaseOS/x86_64/os/"
-  RHEL_APPS_REPO = "http://download.eng.brq.redhat.com/rhel-9/rel-eng/RHEL-9/latest-RHEL-9/compose/AppStream/x86_64/os"
-
-  $rhel_testing_repos = <<-SCRIPT
-echo "
-[demo_base_repo]
-name=Testing Base Repo
-baseurl=#{RHEL_BASE_REPO}
-enabled=1
-gpgcheck=0
-
-[demo_apps_repo]
-name=Testing Apps Repo
-baseurl=#{RHEL_APPS_REPO}
-enabled=1
-gpgcheck=0" > /etc/yum.repos.d/cac.repo
-  SCRIPT
-  config.vm.provision "shell", inline: $rhel_testing_repos
 
   # This will collect the SSH public key used to access the VM. Update the path if needed.
   ssh_pub_key = File.readlines("#{Dir.home}/.ssh/id_rsa.pub").first.strip
@@ -52,6 +32,9 @@ gpgcheck=0" > /etc/yum.repos.d/cac.repo
   echo "ansible ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/ansible
   chmod 0440 /etc/sudoers.d/ansible
 
+  # Ensure filesystem is resized to maximum size
+  btrfs filesystem resize max /home
+
   # Install required packages
   dnf install -y qemu-guest-agent openssh-clients openssh-server
 
@@ -66,6 +49,6 @@ gpgcheck=0" > /etc/yum.repos.d/cac.repo
 
   config.trigger.after :up do |trigger|
     trigger.name = "Execute local script to update Ansible inventory and add SSH key"
-    trigger.run = { inline: "./populate_ansible_inventory.sh" }
+    trigger.run = { inline: "../populate_ansible_inventory.sh" }
   end
 end

--- a/base_vms/populate_ansible_inventory.sh
+++ b/base_vms/populate_ansible_inventory.sh
@@ -10,15 +10,15 @@ ssh-keyscan -H "$IP" >> ~/.ssh/known_hosts 2>/dev/null
 echo "IP address $IP added to known_hosts file."
 
 # Populate the Ansible inventory file with the VM's SSH configuration
-echo "[demo_vm]" > ../base_ansible_env/ansible_inventory
+echo "[demo_vm]" > ../../base_ansible_env/ansible_inventory
 echo "$VAGRANT_SSH_CONFIG" | awk '
 /Host / {host=$2}
 /HostName/ {hostname=$2}
 END {print host, "ansible_host="hostname, "ansible_user=ansible", "ansible_ssh_private_key_file=~/.ssh/id_rsa"}
-' >> ../base_ansible_env/ansible_inventory
+' >> ../../base_ansible_env/ansible_inventory
 
 echo "Inventory file generated successfully!"
-cat ../base_ansible_env/ansible_inventory
+cat ../../base_ansible_env/ansible_inventory
 
 echo "You can connect to the VMs using the following command:"
 echo "$VAGRANT_SSH_CONFIG" | awk '

--- a/base_vms/rhel9/Vagrantfile
+++ b/base_vms/rhel9/Vagrantfile
@@ -1,0 +1,71 @@
+# This Vagrant file will create a RHEL 9 VM using the libvirt provider.
+# It intended to be used only for local tests.
+
+Vagrant.configure("2") do |config|
+  config.vm.provider "libvirt" do |libvirt|
+    libvirt.memory = "2048"
+    libvirt.cpus = 2
+    libvirt.default_prefix = "complytime_"
+    libvirt.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
+  end
+
+  config.vm.define "rhel9" do |rhel|
+    rhel.vm.box = "generic/rhel9"
+    rhel.vm.hostname = "rhel9"
+  end
+
+  # This Vagrantfile is using a publicly available Box and, therefore, without a valid
+  # subscription. Testing repositories can be included as needed.
+  RHEL_BASE_REPO = "http://download.eng.brq.redhat.com/rhel-9/rel-eng/RHEL-9/latest-RHEL-9/compose/BaseOS/x86_64/os/"
+  RHEL_APPS_REPO = "http://download.eng.brq.redhat.com/rhel-9/rel-eng/RHEL-9/latest-RHEL-9/compose/AppStream/x86_64/os"
+
+  $rhel_testing_repos = <<-SCRIPT
+echo "
+[demo_base_repo]
+name=Testing Base Repo
+baseurl=#{RHEL_BASE_REPO}
+enabled=1
+gpgcheck=0
+
+[demo_apps_repo]
+name=Testing Apps Repo
+baseurl=#{RHEL_APPS_REPO}
+enabled=1
+gpgcheck=0" > /etc/yum.repos.d/cac.repo
+  SCRIPT
+  config.vm.provision "shell", inline: $rhel_testing_repos
+
+  # This will collect the SSH public key used to access the VM. Update the path if needed.
+  ssh_pub_key = File.readlines("#{Dir.home}/.ssh/id_rsa.pub").first.strip
+
+  # To customize the VM during its provisioning, write the commands between "-SCRIPT" and "SCRIPT".
+  $bootstrap = <<-SCRIPT
+  # Start the customizations
+  mkdir -p /root/.ssh
+  echo #{ssh_pub_key} >> /home/vagrant/.ssh/authorized_keys
+  echo #{ssh_pub_key} >> /root/.ssh/authorized_keys
+
+  # Configure Ansible user that can elevate privileges without a password
+  useradd -G wheel ansible && mkdir -p /home/ansible/.ssh && echo #{ssh_pub_key} >> /home/ansible/.ssh/authorized_keys
+  chown -R ansible:ansible /home/ansible/.ssh && chmod 700 /home/ansible/.ssh
+  chmod 600 /home/ansible/.ssh/authorized_keys
+  echo "ansible ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/ansible
+  chmod 0440 /etc/sudoers.d/ansible
+
+  # Install required packages
+  dnf install -y qemu-guest-agent openssh-clients openssh-server
+
+  # Install some useful packages
+  dnf install -y git python3-pip tar tree vim -y
+  dnf install -y --nobest openscap-scanner openscap-engine-sce scap-security-guide
+
+  # Upgrade the system
+  dnf upgrade -y
+  SCRIPT
+  config.vm.provision "shell", inline: $bootstrap
+
+  config.trigger.after :up do |trigger|
+    trigger.name = "Execute local script to update Ansible inventory and add SSH key"
+    trigger.run = { inline: "../populate_ansible_inventory.sh" }
+  end
+end


### PR DESCRIPTION
## Summary

Rename the directory `base_rhel9_vm` to `base_vms` so different Vagrant files can be more easily included.
Introduced a Vagrantfile for Fedora.

Also some minor improvements:
- Remove from git the dynamic inventory created by `populate_ansible_inventory.sh`
- Silent a warning regarding the python interpreter.

## Related Issues

- Make it easier to test ComplyTime in a Fedora VM

## Review Hints

You could start both a `rhel9` and `fedora` VM using the instructions from README.md.
Note that Fedora box is using version 41 since it is the last available by Fedora. It will be updated when newer versions are available.