### PR TITLE
feat: updating docs for naming refactor

### DIFF
--- a/CONTENT_TRANSFORMATION.md
+++ b/CONTENT_TRANSFORMATION.md
@@ -2,41 +2,41 @@
 
 The commands for each RHEL9 Profile transform CaC/content to an OSCAL Catalog, Profile(s), and Component Definition(s).
 
-The commands for transforming CaC/content leverage [trestle-bot](https://github.com/complytime/trestle-bot) for authoring OSCAL Content.
+The commands for transforming CaC/content leverage [complyscribe](https://github.com/complytime/complyscribe) for authoring OSCAL Content.
 
 
 ##### Generating OSCAL Profile from RHEL9 Profile with ANSSI content
 
 ```bash
 # Generating an OSCAL Catalog using the anssi cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the anssi OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id anssi --repo-path ~/demos/tmp-trestle-demos --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for anssi_bp28_minimal using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for anssi_bp28_minimal using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_minimal --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for anssi_bp28_intermediary using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-intermediary --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-intermediary --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for anssi_bp28_intermediary using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-intermediary --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-intermediary --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for anssi_bp28_high using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for anssi_bp28_high using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for anssi_bp28_enhanced using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_enhanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-enhanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_enhanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-enhanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for anssi_bp28_enhanced using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_enhanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-enhanced --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_enhanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-enhanced --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 ```
 
@@ -45,28 +45,28 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ```bash
 
 # Generating an OSCAL Catalog using the ccn_rhel9 cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ccn_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ccn_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ccn_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ccn_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ccn_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ccn_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ccn_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ccn_basic using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-basic --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-scribe-demos --oscal-profile ccn_rhel9-basic --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ccn_basic using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-basic --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_basic --repo-path ~/demos/tmp-scribe-demos --oscal-profile ccn_rhel9-basic --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ccn_intermediate using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_intermediate --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-intermediate --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_intermediate --repo-path ~/demos/tmp-scribe-demos --oscal-profile ccn_rhel9-intermediate --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ccn_intermediate using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_intermediate --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-intermediate --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_intermediate --repo-path ~/demos/tmp-scribe-demos --oscal-profile ccn_rhel9-intermediate --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ccn_advanced using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_advanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-advanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_advanced --repo-path ~/demos/tmp-scribe-demos --oscal-profile ccn_rhel9-advanced --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ccn_advanced using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_advanced --repo-path ~/demos/tmp-trestle-demos --oscal-profile ccn_rhel9-advanced --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ccn_advanced --repo-path ~/demos/tmp-scribe-demos --oscal-profile ccn_rhel9-advanced --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with CIS content
@@ -74,34 +74,34 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ```bash
 
 # Generating an OSCAL Catalog using the cis_rhel9 cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id cis_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog cis_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the cis_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id cis_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog cis_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id cis_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog cis_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for cis_server_l1 using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l1_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for cis_server_l1 using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_server --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_server_l1 --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l1_server --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for cis using the cis_rhel9-l2_server profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l2_server --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for cis using the cis_rhel9-l2_server profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_server --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l2_server --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for cis_workstation_l1 using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l1 --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l1_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for cis_workstation_l1 using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l1 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l1_workstation --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l1 --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l1_workstation --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for cis_workstation_l2 using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l2 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l2 --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l2_workstation --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for cis_workstation_l2 using the profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l2 --repo-path ~/demos/tmp-trestle-demos --oscal-profile cis_rhel9-l2_workstation --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cis_workstation_l2 --repo-path ~/demos/tmp-scribe-demos --oscal-profile cis_rhel9-l2_workstation --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with OSPP content
@@ -109,16 +109,16 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ```bash
 
 # Generating an OSCAL Catalog using the ospp cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-scribe-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ospp using the ospp-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ospp --repo-path ~/demos/tmp-scribe-demos --oscal-profile ospp-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 
@@ -126,16 +126,16 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ```bash
 
 # Generating an OSCAL Catalog using the ospp cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ospp --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the ospp OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ospp --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ospp --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ospp using the ospp-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-scribe-demos --oscal-profile ospp-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ospp using the ospp-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-trestle-demos --oscal-profile ospp-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile cui --repo-path ~/demos/tmp-scribe-demos --oscal-profile ospp-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with E8 content
@@ -143,16 +143,16 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ```bash
 
 # Generating an OSCAL Catalog using the e8 cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id e8 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog e8 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the e8 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id e8 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog e8 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id e8 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog e8 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for e8 using the e8-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-trestle-demos --oscal-profile e8-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-scribe-demos --oscal-profile e8-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for e8 using the e8-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-trestle-demos --oscal-profile e8-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile e8 --repo-path ~/demos/tmp-scribe-demos --oscal-profile e8-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with HIPAA content
@@ -160,72 +160,72 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ```bash
 
 # Generating an OSCAL Catalog using the hipaa cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --branch main --committer-name test --committer-email test@redhat.com --dry-run  
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-catalog hipaa --branch main --committer-name test --committer-email test@redhat.com --dry-run  
 
 # Generating an OSCAL Profile leveraging the hipaa OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-catalog hipaa --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-catalog hipaa --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for hipaa using the hipaa-addressable profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-addressable --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-profile hipaa-addressable --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for hipaa using the hipaa-addressable profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-addressable --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-profile hipaa-addressable --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for hipaa using the hipaa-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-profile hipaa-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for hipaa using the hipaa-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-profile hipaa-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for hipaa using the hipaa-required profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-required --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-profile hipaa-required --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for hipaa using the hipaa-required profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-trestle-demos --oscal-profile hipaa-required --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile hipaa --repo-path ~/demos/tmp-scribe-demos --oscal-profile hipaa-required --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with ISM content
 
 ```bash
 # Generating an OSCAL Catalog using the ism_o cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --branch main --committer-name test --committer-email test@redhat.com --dry-run  
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ism_o --branch main --committer-name test --committer-email test@redhat.com --dry-run  
 
 # Generating an OSCAL Profile leveraging the ism_o OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-catalog ism_o --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-catalog ism_o --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ism_o using the ism_o-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-profile ism_o-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ism_o using the ism_o-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-profile ism_o-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ism_o using the ism_o-secret profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-profile ism_o-secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ism_o using the ism_o-secret profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-secret --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-profile ism_o-secret --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for ism_o using the ism_o-top_secret profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-top_secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-profile ism_o-top_secret --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for ism_o using the ism_o-top_secret profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-trestle-demos --oscal-profile ism_o-top_secret --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile ism_o --repo-path ~/demos/tmp-scribe-demos --oscal-profile ism_o-top_secret --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 ##### Generating OSCAL Profile from RHEL9 Profile with PCI-DSS content
 
 ```bash
 
 # Generating an OSCAL Catalog using the pcidss_4 cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id pcidss_4 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog pcidss_4 --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the pcidss_4 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id pcidss_4 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog pcidss_4 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for pci-dss using the pcidss_4-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-trestle-demos --oscal-profile pcidss_4-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-scribe-demos --oscal-profile pcidss_4-base --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for pci-dss using the pcidss_4-base profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-trestle-demos --oscal-profile pcidss_4-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss --repo-path ~/demos/tmp-scribe-demos --oscal-profile pcidss_4-base --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile with STIG content
@@ -233,55 +233,55 @@ poetry run trestlebot sync-cac-content component-definition --product rhel9 --ca
 ```bash
 
 # Generating an OSCAL Catalog using the stig_rhel9 cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run 
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog stig_rhel9 --branch main --committer-name test --committer-email test@redhat.com --dry-run 
 
 # Generating an OSCAL Profile leveraging the stig_rhel9 OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog stig_rhel9 --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-low profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for pci-dss using the stig_rhel9-low profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-low --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for pci-dss using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-medium --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for pci-dss using the stig_rhel9-high profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for pci-dss using the stig_rhel9-high profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 ##### Generating OSCAL Profile from RHEL9 Profile for stig_gui with STIG content
 
 ```bash
 # Generating an OSCAL Catalog using the stig_rhel9 cac-policy-id from CaC/content.
-poetry run trestlebot sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe sync-cac-content catalog --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog stig_gui --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Generating an OSCAL Profile leveraging the stig_gui OSCAL Catalog and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog stig_gui --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-policy-id stig_rhel9 --repo-path ~/demos/tmp-scribe-demos --oscal-catalog stig_gui --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-low profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-low --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for stig_gui using the stig_rhel9-low profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-low --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-low --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-medium --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for stig_gui using the stig_rhel9-medium profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-medium --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-medium --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Generating an OSCAL Component Definition for stig_gui using the stig_rhel9-high profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-high --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Updating an OSCAL Component Definition to include a validation component for stig_gui using the stig_rhel9-high profile created and the RHEL9 CaC/content.
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-trestle-demos --oscal-profile stig_rhel9-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile stig_gui --repo-path ~/demos/tmp-scribe-demos --oscal-profile stig_rhel9-high --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ComplyTime Demos
 
-This repository is intended to be used as base for [ComplyTime](https://github.com/complytime/complytime) and [trestlebot](https://github.com/complytime/trestle-bot) Demos.
+This repository is intended to be used as base for [complyctl](https://github.com/complytime/complyctl) and [complyscribe](https://github.com/complytime/complyscribe) Demos.
 
-As ComplyTime and trestlebot are evolving on their features, as well as [CaC/content](https://github.com/complianceAsCode/content) are being transformed to OSCAL and vice-versa, we can show more complex demos with real content.
+As complyctl and complyscribe are evolving on their features, as well as [CaC/content](https://github.com/complianceAsCode/content) are being transformed to OSCAL and vice versa, we can show more complex demos with real content.
 
 This repository targets some goals:
 * Standardize the demos so they can be easily extended
@@ -59,12 +59,12 @@ Or you can connect via SSH using the hint from `./populate_ansible_inventory.sh`
 ssh ansible@192.168.122.161
 ```
 
-### Populate ComplyTime binaries
+### Populate complyctl binaries
 
-Execute the `populate_complytime_vm.yml` Playbook to build ComplyTime binaries locally and send them to the Demo VM.
-For now, the ComplyTime binaries are built locally, so it is required the `https://github.com/complytime/complytime.git` repository cloned and the minimal packages necessary to build Go code. More information could be found [here](https://github.com/complytime/complytime/blob/main/docs/INSTALLATION.md)
+Execute the `populate_complytime_vm.yml` Playbook to build complyctl binaries locally and send them to the Demo VM.
+For now, the complyctl binaries are built locally, so it is required the `https://github.com/complytime/complyctl.git` repository cloned and the minimal packages necessary to build Go code. More information could be found [here](https://github.com/complytime/complytime/blob/main/docs/INSTALLATION.md)
 
-Once ComplyTime can be built locally, there is a green light to move forward with the Ansible Playbooks.
+Once complyctl can be built locally, there is a green light to move forward with the Ansible Playbooks.
 
 ```bash
 cd ../base_ansible_env
@@ -90,7 +90,7 @@ After running this Playbook a directory structure similar to this is expected in
 
 ### Populate OSCAL Content
 
-In order to speed up the tests, this repository contains OSCAL content transformed from CaC based on ansi_bp28_minimal profile for RHEL 9.
+In order to speed up the tests, this repository contains OSCAL content transformed from CaC based on anssi_bp28_minimal profile for RHEL 9.
 
 ```bash
 ansible-playbook populate_complytime_anssi_content.yml
@@ -116,20 +116,20 @@ After running this Playbook a directory structure similar to this is expected in
 ```
 
 #### Regenerate ANSSI content
-For reference, these were the commands used with trestlebot to transform the ANSSI content in this example:
+For reference, these were the commands used with complyscribe to transform the ANSSI content in this example:
 
 ```bash
 # Create a OSCAL catalog based on ANSSI control file in CaC/content
-poetry run trestlebot catalog --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
+poetry run complyscribe catalog --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs --oscal-catalog anssi --branch main --committer-name test --committer-email test@redhat.com --dry-run
 
 # Once a catalog is available, the ANSSI profiles can be created based on control file information in CaC/content
-poetry run trestlebot sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs/ --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content profile --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-policy-id anssi --repo-path ~/LABs/trestlebot-labs/ --oscal-catalog anssi --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # With a profile available, an OSCAL Component Definition can be created using information from anssi_bp28_minimal profile for RHEL 9 product
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile anssi_bp28_minimal --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile anssi_bp28_minimal --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type software --committer-name test --committer-email test@redhat.com --branch main --dry-run
 
 # Finally the new Component Definition can be updated to include a validation component, to be used by openscap-plugin later
-poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile ~/CaC/Forks/content/products/rhel9/profiles/anssi_bp28_minimal.profile --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
+poetry run complyscribe sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/Forks/content --cac-profile ~/CaC/Forks/content/products/rhel9/profiles/anssi_bp28_minimal.profile --repo-path ~/LABs/trestlebot-labs --oscal-profile anssi-minimal --component-definition-type validation --committer-name test --committer-email test@redhat.com --branch main --dry-run
 ```
 
 After these commands, the generated component definition and the chosen profile files were copied to `base_ansible_env/files` to be used with `populate_complytime_anssi_content.yml` Playbook.
@@ -139,13 +139,13 @@ After these commands, the generated component definition and the chosen profile 
 The commands for transforming CaC/content are organized by policy_id in the [CONTENT_TRANSFORMATION.md](https://github.com/complytime/complytime-demos/blob/d403cb455f4bf6f4e4dd9e7d7fc724d9e0b0e321/CONTENT_TRANSFORMATION.md).
 
 
-### Try ComplyTime commands
+### Try complyctl commands
 
 Once the Demo VM is populated with ComplyTime binaries and OSCAL content, here are some nice commands to try:
 ```bash
-complytime list
-complytime plan anssi_bp28_minimal
-complytime generate
-complytime scan
+complyctl list
+complyctl plan anssi_bp28_minimal
+complyctl generate
+complyctl scan
 tree -a
 ```


### PR DESCRIPTION
## Summary
This PR updates the documentation in `complytime-demos` for consistency with the naming refactor of `complyscribe` and `complyctl`, formerly `trestle-bot` and `complytime` respectively. 

## Related Issues

- Closes #16 

## Review Hints

- Updates made in the `README.md` and `CONTENT_TRANSFORMATION.md`
