### PR TITLE
fix: update go-git/v5 to resolve security vulnerabilities

### DIFF
--- a/tools/gemara2ampel/go.mod
+++ b/tools/gemara2ampel/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/goccy/go-yaml v1.19.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/tools/gemara2ampel/go.sum
+++ b/tools/gemara2ampel/go.sum
@@ -42,8 +42,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/goccy/go-yaml v1.19.1 h1:3rG3+v8pkhRqoQ/88NYNMHYVGYztCOCIZ7UQhu7H+NE=
 github.com/goccy/go-yaml v1.19.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=


### PR DESCRIPTION
## Summary

Bumps `github.com/go-git/go-git/v5` from 5.19.0 to 5.19.1 (patch) in `tools/gemara2ampel` to resolve open security advisories.

Advisories resolved:
- https://github.com/advisories/GHSA-crhj-59gh-8x96
- https://github.com/advisories/GHSA-m7cr-m3pv-hgrp

Changes:
- Updated `tools/gemara2ampel/go.mod`
- Regenerated `tools/gemara2ampel/go.sum`

## Related Issues

- Closes Dependabot alerts 7 and 8

## Review Hints

- This is a patch-level bump (5.19.0 -> 5.19.1) of a transitive dependency, so the risk is low.
- The Go build and tests pass successfully after the update.
- Only `go.mod` and `go.sum` in `tools/gemara2ampel/` are affected.