### PR TITLE
fix: update go.work to match module Go version requirement

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.25.5
+go 1.25.9
 
 use ./tools/gemara2ampel


### PR DESCRIPTION
## Summary

Fix the Go workspace version mismatch that causes CodeQL Go analysis and local builds to fail.

The `go.work` file specified `go 1.25.5` but `tools/gemara2ampel/go.mod` requires `go 1.25.9`. This caused:
- **CodeQL "Analyze (go)"** to fail on every PR
- **Local `go build`/`go test`** to fail with: `go: module . listed in go.work file requires go >= 1.25.9, but go.work lists go 1.25.5`
- **Dependabot** to fail updating `github.com/gemaraproj/go-gemara`

## Changes

- `go.work`: `go 1.25.5` -> `go 1.25.9`

## Verification

- `go build ./...` passes
- `go test ./...` passes (all tests in `gemara2ampel/go/ampel`)
- `golangci-lint run ./tools/gemara2ampel/...` reports 0 issues

## Related Issues

- Addresses @sonupreetam's [comment](https://github.com/complytime/complytime-demos/pull/44#issuecomment-4679641568) about CodeQL failure
