### PR TITLE
fix: migrate gemara2ampel to go-gemara v0.5.0+ API

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.25.9
+go 1.25.11
 
 use ./tools/gemara2ampel

--- a/tools/gemara2ampel/ampel/ampel.go
+++ b/tools/gemara2ampel/ampel/ampel.go
@@ -244,7 +244,7 @@ func assessmentPlanToTenets(
 	methodIndex := 0
 	for _, method := range plan.EvaluationMethods {
 		// Only process automated methods
-		if !isAutomatedMethod(method.Type) {
+		if !isAutomatedMethod(method) {
 			continue
 		}
 
@@ -315,18 +315,14 @@ func getTenetName(method gemara.AcceptedMethod, evidenceReq string) string {
 	}
 
 	// Fallback to method type
-	return fmt.Sprintf("%s verification", method.Type)
+	return fmt.Sprintf("%s verification", method.Type.String())
 }
 
-// isAutomatedMethod checks if an evaluation method type can be automated.
-func isAutomatedMethod(methodType string) bool {
-	automatedTypes := map[string]bool{
-		"automated":       true,
-		"gate":            true,
-		"behavioral":      true,
-		"autoremediation": true,
-	}
-	return automatedTypes[methodType]
+// isAutomatedMethod checks if an evaluation method can be automated.
+// In go-gemara v0.5.0, automation is determined by the Mode field
+// (ModeAutomated) rather than the Type field.
+func isAutomatedMethod(method gemara.AcceptedMethod) bool {
+	return method.Mode == gemara.ModeAutomated
 }
 
 // FromPolicies converts multiple Gemara Layer-3 Policies to an Ampel PolicySet.
@@ -470,11 +466,11 @@ func FromPolicyWithImports(policy *gemara.Policy, opts ...PolicySetOption) (*Pol
 	for _, importedPolicyRef := range policy.Imports.Policies {
 		// Create a Policy with Source reference for external policies
 		extPolicy := &Policy{
-			Id: extractPolicyIdFromReference(importedPolicyRef),
+			Id: extractPolicyIdFromReference(importedPolicyRef.ReferenceId),
 			Source: &PolicyRef{
-				Id: extractPolicyIdFromReference(importedPolicyRef),
+				Id: extractPolicyIdFromReference(importedPolicyRef.ReferenceId),
 				Location: &ResourceDescriptor{
-					Uri: importedPolicyRef,
+					Uri: importedPolicyRef.ReferenceId,
 				},
 			},
 		}

--- a/tools/gemara2ampel/ampel/ampel_test.go
+++ b/tools/gemara2ampel/ampel/ampel_test.go
@@ -110,7 +110,8 @@ func TestGenerateCELFromMethod(t *testing.T) {
 		{
 			name: "SLSA provenance",
 			method: gemara.AcceptedMethod{
-				Type: "automated",
+				Type: gemara.MethodGate,
+				Mode: gemara.ModeAutomated,
 			},
 			evidenceReq:     "SLSA provenance with trusted builder",
 			expectedInCode:  "slsa.dev/provenance/v1",
@@ -119,7 +120,8 @@ func TestGenerateCELFromMethod(t *testing.T) {
 		{
 			name: "Vulnerability scan",
 			method: gemara.AcceptedMethod{
-				Type: "automated",
+				Type: gemara.MethodBehavioral,
+				Mode: gemara.ModeAutomated,
 			},
 			evidenceReq:     "Vulnerability scan with no critical findings",
 			expectedInCode:  "in-toto.io/Statement",
@@ -320,7 +322,7 @@ func createTestPolicy() *gemara.Policy {
 				Id:   "author-001",
 			},
 		},
-		Contacts: gemara.Contacts{
+		Contacts: gemara.RACI{
 			Responsible: []gemara.Contact{
 				{Name: "IT Director"},
 			},
@@ -344,7 +346,8 @@ func createTestPolicy() *gemara.Policy {
 					EvidenceRequirements: "SLSA provenance with trusted builder",
 					EvaluationMethods: []gemara.AcceptedMethod{
 						{
-							Type:        "automated",
+							Type:        gemara.MethodGate,
+							Mode:        gemara.ModeAutomated,
 							Description: "Verify SLSA provenance",
 						},
 					},
@@ -362,22 +365,23 @@ func createTestAssessmentPlan() gemara.AssessmentPlan {
 		EvidenceRequirements: "SLSA provenance with trusted builder",
 		EvaluationMethods: []gemara.AcceptedMethod{
 			{
-				Type:        "automated",
+				Type:        gemara.MethodGate,
+				Mode:        gemara.ModeAutomated,
 				Description: "Verify SLSA provenance",
 			},
 		},
 	}
 }
 
-func createTestCatalog() *gemara.Catalog {
-	return &gemara.Catalog{
+func createTestCatalog() *gemara.ControlCatalog {
+	return &gemara.ControlCatalog{
 		Title: "Test Catalog",
 		Metadata: gemara.Metadata{
 			Id:          "catalog-001",
 			Version:     "1.0",
 			Description: "Test catalog",
 		},
-		Families: []gemara.Family{
+		Groups: []gemara.Group{
 			{
 				Id:          "CF-01",
 				Title:       "Test Control Family",
@@ -389,7 +393,7 @@ func createTestCatalog() *gemara.Catalog {
 				Id:        "CTRL-01",
 				Title:     "Test Control",
 				Objective: "Test control objective",
-				Family:    "CF-01",
+				Group:     "CF-01",
 				AssessmentRequirements: []gemara.AssessmentRequirement{
 					{
 						Id:   "REQ-01",
@@ -417,7 +421,7 @@ func TestFromPolicies(t *testing.T) {
 				Name: "Test Author 2",
 			},
 		},
-		Contacts: gemara.Contacts{},
+		Contacts: gemara.RACI{},
 		Scope:    gemara.Scope{},
 		Imports:  gemara.Imports{},
 		Adherence: gemara.Adherence{
@@ -429,7 +433,8 @@ func TestFromPolicies(t *testing.T) {
 					EvidenceRequirements: "Vulnerability scan with no critical findings",
 					EvaluationMethods: []gemara.AcceptedMethod{
 						{
-							Type:        "automated",
+							Type:        gemara.MethodBehavioral,
+							Mode:        gemara.ModeAutomated,
 							Description: "Verify vulnerability scan results",
 						},
 					},
@@ -469,9 +474,9 @@ func TestFromPolicyWithImports(t *testing.T) {
 	policy := createTestPolicy()
 	policy.Metadata.Id = "main-policy"
 	policy.Title = "Main Policy"
-	policy.Imports.Policies = []string{
-		"git+https://github.com/carabiner-dev/policies#slsa/slsa-builder-id.json",
-		"git+https://github.com/carabiner-dev/policies#vuln/vuln-scan.json",
+	policy.Imports.Policies = []gemara.ArtifactMapping{
+		{ReferenceId: "git+https://github.com/carabiner-dev/policies#slsa/slsa-builder-id.json"},
+		{ReferenceId: "git+https://github.com/carabiner-dev/policies#vuln/vuln-scan.json"},
 	}
 
 	policySet, err := FromPolicyWithImports(policy)
@@ -731,7 +736,8 @@ func TestContextMapping(t *testing.T) {
 					},
 					EvaluationMethods: []gemara.AcceptedMethod{
 						{
-							Type:        "automated",
+							Type:        gemara.MethodGate,
+							Mode:        gemara.ModeAutomated,
 							Description: "Verify SLSA builder ID",
 						},
 					},
@@ -825,7 +831,8 @@ func TestContextMapping_ParameterIDsPreserved(t *testing.T) {
 					},
 					EvaluationMethods: []gemara.AcceptedMethod{
 						{
-							Type:        "automated",
+							Type:        gemara.MethodGate,
+							Mode:        gemara.ModeAutomated,
 							Description: "Test method",
 						},
 					},
@@ -868,7 +875,8 @@ func TestContextMapping_RuntimeParameters(t *testing.T) {
 					},
 					EvaluationMethods: []gemara.AcceptedMethod{
 						{
-							Type:        "automated",
+							Type:        gemara.MethodGate,
+							Mode:        gemara.ModeAutomated,
 							Description: "Verify runtime value",
 						},
 					},

--- a/tools/gemara2ampel/ampel/catalog.go
+++ b/tools/gemara2ampel/ampel/catalog.go
@@ -10,14 +10,14 @@ type CatalogEnrichment struct {
 	// Requirement is the specific assessment requirement
 	Requirement *gemara.AssessmentRequirement
 
-	// Family is the control family
-	Family *gemara.Family
+	// Family is the control group (formerly family)
+	Family *gemara.Group
 }
 
 // lookupRequirement finds a requirement in the catalog by its ID.
 // Returns the control containing the requirement, the requirement itself,
 // and the control family, or nil if not found.
-func lookupRequirement(catalog *gemara.Catalog, requirementID string) *CatalogEnrichment {
+func lookupRequirement(catalog *gemara.ControlCatalog, requirementID string) *CatalogEnrichment {
 	if catalog == nil || requirementID == "" {
 		return nil
 	}
@@ -28,11 +28,11 @@ func lookupRequirement(catalog *gemara.Catalog, requirementID string) *CatalogEn
 		for j := range control.AssessmentRequirements {
 			req := &control.AssessmentRequirements[j]
 			if req.Id == requirementID {
-				// Find the family for this control
-				var family *gemara.Family
-				for k := range catalog.Families {
-					if catalog.Families[k].Id == control.Family {
-						family = &catalog.Families[k]
+				// Find the group for this control
+				var family *gemara.Group
+				for k := range catalog.Groups {
+					if catalog.Groups[k].Id == control.Group {
+						family = &catalog.Groups[k]
 						break
 					}
 				}

--- a/tools/gemara2ampel/ampel/cel.go
+++ b/tools/gemara2ampel/ampel/cel.go
@@ -44,11 +44,13 @@ var DefaultCELTemplates = map[string]string{
 
 // MethodTypeToCELTemplate maps Gemara evaluation method types to
 // default CEL template names for common scenarios.
-var MethodTypeToCELTemplate = map[string]string{
-	"automated":       "generic-field-equals",
-	"gate":            "generic-predicate-type",
-	"behavioral":      "generic-field-equals",
-	"autoremediation": "generic-field-equals",
+// In go-gemara v0.5.0, MethodType is an int enum (MethodBehavioral,
+// MethodIntent, MethodRemediation, MethodGate).
+var MethodTypeToCELTemplate = map[gemara.MethodType]string{
+	gemara.MethodBehavioral:  "generic-field-equals",
+	gemara.MethodIntent:      "generic-field-equals",
+	gemara.MethodGate:        "generic-predicate-type",
+	gemara.MethodRemediation: "generic-field-equals",
 }
 
 // GenerateCEL creates a CEL expression from a template and parameters.

--- a/tools/gemara2ampel/ampel/options.go
+++ b/tools/gemara2ampel/ampel/options.go
@@ -6,7 +6,7 @@ import "github.com/gemaraproj/go-gemara"
 // to Ampel verification policies.
 type TransformOptions struct {
 	// Catalog is an optional catalog used to enrich tenets with control details
-	Catalog *gemara.Catalog
+	Catalog *gemara.ControlCatalog
 
 	// CELTemplates provides custom CEL code templates for generating verification logic
 	// Key: template name, Value: CEL template string with {{.Parameter}} placeholders
@@ -34,7 +34,7 @@ type TransformOption func(*TransformOptions)
 //   - Use requirement text as tenet titles (more descriptive than evidence requirements)
 //   - Add control references to policy metadata (Meta.Controls)
 //   - Include control family information (framework and class)
-func WithCatalog(catalog *gemara.Catalog) TransformOption {
+func WithCatalog(catalog *gemara.ControlCatalog) TransformOption {
 	return func(opts *TransformOptions) {
 		opts.Catalog = catalog
 	}

--- a/tools/gemara2ampel/cmd/ampel_export/cli/convert.go
+++ b/tools/gemara2ampel/cmd/ampel_export/cli/convert.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"gemara2ampel/go/ampel"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/gemaraproj/go-gemara/fetcher"
 )
 
 // convertPolicy handles the main policy conversion logic
@@ -17,9 +19,10 @@ func convertPolicy(path string) error {
 	defaultOutputFile := getDefaultOutputFilename(path)
 
 	// Load the policy
-	policy := &gemara.Policy{}
-	pathWithScheme := fmt.Sprintf("file://%s", path)
-	if err := policy.LoadFile(pathWithScheme); err != nil {
+	ctx := context.Background()
+	f := &fetcher.URI{}
+	policy, err := gemara.Load[gemara.Policy](ctx, f, path)
+	if err != nil {
 		return fmt.Errorf("failed to load policy: %w", err)
 	}
 
@@ -28,9 +31,8 @@ func convertPolicy(path string) error {
 
 	// Load catalog if provided
 	if catalogPath != "" {
-		catalog := &gemara.Catalog{}
-		catalogPathWithScheme := fmt.Sprintf("file://%s", catalogPath)
-		if err := catalog.LoadFile(catalogPathWithScheme); err != nil {
+		catalog, err := gemara.Load[gemara.ControlCatalog](ctx, f, catalogPath)
+		if err != nil {
 			return fmt.Errorf("failed to load catalog: %w", err)
 		}
 		transformOpts = append(transformOpts, ampel.WithCatalog(catalog))

--- a/tools/gemara2ampel/docs/FIELD_MAPPING.md
+++ b/tools/gemara2ampel/docs/FIELD_MAPPING.md
@@ -341,15 +341,24 @@ attestation.predicate.builder.id == context["builder-id"]
 
 ## Evaluation Method Filtering
 
-Only certain evaluation method types are converted to automated tenets:
+In go-gemara v0.5.0, evaluation methods have two separate fields:
+- **`Type`** (`MethodType`): The category of evaluation — `Behavioral`, `Intent`, `Remediation`, `Gate`
+- **`Mode`** (`ModeType`): Whether the method is `Manual` or `Automated`
 
-| Method Type | Included in Ampel? | Rationale |
-| ----------- | ------------------ | --------- |
-| `automated` | ✅ Yes | Directly automatable with CEL |
-| `gate` | ✅ Yes | Pre-deployment checks |
-| `behavioral` | ✅ Yes | Runtime verification |
-| `autoremediation` | ✅ Yes | Post-verification actions |
-| `manual` | ❌ No | Cannot be automated |
+Only methods with `Mode: Automated` are converted to Ampel tenets. The `Type` field
+determines which CEL template is used:
+
+| Mode | Included in Ampel? | Rationale |
+| ---- | ------------------ | --------- |
+| `Automated` | Yes | Can be expressed as CEL verification logic |
+| `Manual` | No | Requires human evaluation |
+
+| Method Type | Default CEL Template | Description |
+| ----------- | -------------------- | ----------- |
+| `Gate` | `generic-predicate-type` | Pre-deployment pass/fail checks |
+| `Behavioral` | `generic-field-equals` | Runtime behavior verification |
+| `Intent` | `generic-field-equals` | Intent/state verification |
+| `Remediation` | `generic-field-equals` | Post-verification remediation actions |
 
 ## Scope to CEL Filter Mapping
 

--- a/tools/gemara2ampel/go.mod
+++ b/tools/gemara2ampel/go.mod
@@ -5,7 +5,7 @@ go 1.25.11
 require (
 	github.com/carabiner-dev/policy v0.5.1
 	github.com/carabiner-dev/signer v0.5.2
-	github.com/gemaraproj/go-gemara v0.5.0
+	github.com/gemaraproj/go-gemara v0.6.0
 	github.com/in-toto/attestation v1.2.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/tools/gemara2ampel/go.sum
+++ b/tools/gemara2ampel/go.sum
@@ -119,8 +119,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/gemaraproj/go-gemara v0.5.0 h1:sKDj3R7fX8tdlksShWGCLUl/sLvo+tGh1xAFs1JaoHU=
-github.com/gemaraproj/go-gemara v0.5.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
+github.com/gemaraproj/go-gemara v0.6.0 h1:UvmPgRTK4U6C9Z/PhAvVIbjlnvU1IRTSneE/t4PWPks=
+github.com/gemaraproj/go-gemara v0.6.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=

--- a/tools/gemara2ampel/test_data/gemara-policy-with-params.yaml
+++ b/tools/gemara2ampel/test_data/gemara-policy-with-params.yaml
@@ -38,7 +38,8 @@ adherence:
           accepted-values:
             - "3"
       evaluation-methods:
-        - type: automated
+        - type: Gate
+          mode: Automated
           description: Verify SLSA builder ID matches expected value
     - id: vuln-scan-check
       requirement-id: VULN-REQ-001
@@ -57,5 +58,6 @@ adherence:
           accepted-values:
             - "0"
       evaluation-methods:
-        - type: automated
+        - type: Behavioral
+          mode: Automated
           description: Check vulnerability scan results


### PR DESCRIPTION
## Summary

Migrate `gemara2ampel` to the breaking API changes introduced in go-gemara v0.5.0, which were pulled in transitively via the `carabiner-dev/signer` upgrade attempted in Dependabot PR #46.

The go-gemara v0.5.0 release restructured several core types. This PR manually bumps the dependency (to v0.6.0, which is API-compatible with v0.5.0) and adapts all source code, tests, test data, and documentation to the new API.

## Changes

### Type renames (4 files)
- `gemara.Catalog` -> `gemara.ControlCatalog` (`options.go`, `catalog.go`, `convert.go`, `ampel_test.go`)
- `gemara.Family` -> `gemara.Group` (`catalog.go`, `ampel_test.go`)
- `gemara.Contacts` -> `gemara.RACI` (`ampel_test.go`)
- `control.Family` -> `control.Group` (`catalog.go`, `ampel_test.go`)
- `catalog.Families` -> `catalog.Groups` (`catalog.go`)

### MethodType + ModeType split (3 files)
- `isAutomatedMethod` now checks `method.Mode == gemara.ModeAutomated` instead of matching against a map of type strings (`ampel.go`)
- `MethodTypeToCELTemplate` map keys changed from strings to `gemara.MethodType` constants (`cel.go`)
- `method.Type.String()` used for formatting since `MethodType` is now an int enum (`ampel.go`)

### ArtifactMapping (1 file)
- `policy.Imports.Policies` changed from `[]string` to `[]gemara.ArtifactMapping`; uses `.ReferenceId` where the string value was used (`ampel.go`)

### Loader API (1 file)
- `policy.LoadFile(path)` / `catalog.LoadFile(path)` replaced with `gemara.Load[T](ctx, fetcher, source)` using `fetcher.URI` (`convert.go`)

### Other
- `go.work`: `go 1.25.5` -> `go 1.25.11`
- `go.mod`: `go-gemara` upgraded to v0.6.0
- `test_data/gemara-policy-with-params.yaml`: `type: automated` -> `type: Gate/Behavioral` + `mode: Automated`
- `docs/FIELD_MAPPING.md`: updated evaluation method filtering section for the MethodType+ModeType model

## Verification

```
$ cd tools/gemara2ampel
$ go build ./...   # clean
$ go test ./...    # all pass
$ go vet ./...     # clean
```

## Review Hints

- The most significant behavioral change is in `isAutomatedMethod`: it no longer checks a hardcoded list of type strings. Instead, it checks `method.Mode == gemara.ModeAutomated`. This is semantically correct - the old API conflated "what kind of check" with "how it runs," and the new API separates them.
- The `MethodTypeToCELTemplate` map now includes `gemara.MethodIntent` (new in v0.5.0) mapped to `generic-field-equals`, matching the pattern used by `MethodBehavioral` and `MethodRemediation`.
- Test YAML data was updated to match the new YAML serialization format (`type: Gate` + `mode: Automated` with capitalized enum strings).
- The `go get` for the `fetcher` subpackage pulled go-gemara to v0.6.0 (latest). The v0.6.0 API is compatible with v0.5.0 for all types used in this codebase.

## Related Issues

- Closes #48
- Supersedes Dependabot PR #46 (which only bumped the dependency without adapting source code)