### PR TITLE
fix(ci): add missing pull-requests: read permission for call_reusable_ci job

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -17,3 +17,7 @@ jobs:
   call_reusable_ci:
     name: Standardized CI
     uses: complytime/org-infra/.github/workflows/reusable_ci.yml@main
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read


### PR DESCRIPTION
## Summary
Fixes the CI startup_failure caused by a missing permission on the call_reusable_ci job.
The reusable workflow complytime/org-infra/.github/workflows/reusable_ci.yml contains a megalinter job that requires pull-requests: read. The workflow-level pull-requests: none in ci_checks.yml prevented the reusable workflow from obtaining this permission, since GitHub Actions does not allow reusable workflows to escalate permissions beyond what the caller grants.
## Changes
Added job-level permissions to call_reusable_ci:
```
permissions:
  contents: read
  issues: read
  pull-requests: read
```
issues is scoped to read at the job level (narrower than the workflow-level write) following the Principle of Least Privilege, since CI linting does not need write access to issues.

## References
- Closes #51
- Same fix applied in complypack: complypack#57 (https://github.com/complytime/complypack/pull/57)